### PR TITLE
fix aws chime to aws chime-sdk-voice

### DIFF
--- a/src/resources/server/config/config_asterisk.sh
+++ b/src/resources/server/config/config_asterisk.sh
@@ -17,8 +17,8 @@ echo "PHONE_NUMBER: ${PHONE_NUMBER}"
 echo "INSTANCE_ID: ${INSTANCE_ID}"
 
 
-aws chime put-voice-connector-origination --voice-connector-id ${VOICE_CONNECTOR} --origination '{"Routes": [{"Host": "'${PUBLIC_IP}'","Port": 5060,"Protocol": "UDP","Priority": 1,"Weight": 1}],"Disabled": false}'
-aws chime put-voice-connector-termination --voice-connector-id ${VOICE_CONNECTOR} --termination '{"CpsLimit": 1, "CallingRegions": ["US"], "CidrAllowedList": ["'${PUBLIC_IP}'/32"], "Disabled": false}'
+aws chime-sdk-voice put-voice-connector-origination --voice-connector-id ${VOICE_CONNECTOR} --origination '{"Routes": [{"Host": "'${PUBLIC_IP}'","Port": 5060,"Protocol": "UDP","Priority": 1,"Weight": 1}],"Disabled": false}'
+aws chime-sdk-voice put-voice-connector-termination --voice-connector-id ${VOICE_CONNECTOR} --termination '{"CpsLimit": 1, "CallingRegions": ["US"], "CidrAllowedList": ["'${PUBLIC_IP}'/32"], "Disabled": false}'
 
 
 usermod -aG audio,dialout asterisk

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1477,8 +1477,8 @@ echo "PHONE_NUMBER: \${PHONE_NUMBER}"
 echo "INSTANCE_ID: \${INSTANCE_ID}"
 
 
-aws chime put-voice-connector-origination --voice-connector-id \${VOICE_CONNECTOR} --origination '{"Routes": [{"Host": "'\${PUBLIC_IP}'","Port": 5060,"Protocol": "UDP","Priority": 1,"Weight": 1}],"Disabled": false}'
-aws chime put-voice-connector-termination --voice-connector-id \${VOICE_CONNECTOR} --termination '{"CpsLimit": 1, "CallingRegions": ["US"], "CidrAllowedList": ["'\${PUBLIC_IP}'/32"], "Disabled": false}'
+aws chime-sdk-voice put-voice-connector-origination --voice-connector-id \${VOICE_CONNECTOR} --origination '{"Routes": [{"Host": "'\${PUBLIC_IP}'","Port": 5060,"Protocol": "UDP","Priority": 1,"Weight": 1}],"Disabled": false}'
+aws chime-sdk-voice put-voice-connector-termination --voice-connector-id \${VOICE_CONNECTOR} --termination '{"CpsLimit": 1, "CallingRegions": ["US"], "CidrAllowedList": ["'\${PUBLIC_IP}'/32"], "Disabled": false}'
 
 
 usermod -aG audio,dialout asterisk


### PR DESCRIPTION
Fixes #

## About

The "aws chime" command now returns an error, so change to "aws chime-sdk-voice".


## Predicted Cause of Error

The error message was difficult to understand and resolve, probably due to migration from the Amazon Chime namespace.
https://docs.aws.amazon.com/chime-sdk/latest/dg/migrate-from-chm-namespace.html

```bash
# Run with AdministratorAccess policy
$ aws chime put-voice-connector-origination --voice-connector-id fcwftymex1lpaoyai9xhah --origination '{"Routes": [{"Host": "54.156.115.168","Port": 5060,"Protocol": "UDP","Priority": 1,"Weight": 1}],"Disabled": false}'

An error occurred (ForbiddenException) when calling the PutVoiceConnectorOrigination operation: Account Id 706162977618 is not authorized to call deprecated Amazon Chime SDK API on the "chime" endpoint, use one of the "*-chime*" endpoints instead.
```



## Errors to be resolved

CDK Command
![スクリーンショット 2024-03-06 0 22 42](https://github.com/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/assets/37532269/a4866591-7b68-4f5f-9fed-4a8d6313cc05)

```
amazon-chime-sdk-call-analytics-real-time-summarizer:  success: Published 5d81fcb10b0212b4b16db171a288632e9bed931affb207124984dcbf96d43fd5:706162977618-us-east-1
amazon-chime-sdk-call-analytics-real-time-summarizer: deploying... [1/1]
amazon-chime-sdk-call-analytics-real-time-summarizer: creating CloudFormation changeset...
23:22:25 | CREATE_FAILED        | AWS::EC2::Instance                        | ServerResourcesIns...43aef0c00e63d6511d
Received FAILURE signal with UniqueId i-01432672bfed0348a


 ❌  amazon-chime-sdk-call-analytics-real-time-summarizer failed: Error: The stack named amazon-chime-sdk-call-analytics-real-time-summarizer failed to deploy: CREATE_FAILED (The following resource(s) failed to create: [ServerResourcesInstance6D1E6643aef0c00e63d6511d]. ): Received FAILURE signal with UniqueId i-01432672bfed0348a
    at FullCloudFormationDeployment.monitorDeployment (/Users/yutaokos/src/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/node_modules/aws-cdk/lib/index.js:431:10615)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.deployStack2 [as deployStack] (/Users/yutaokos/src/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/node_modules/aws-cdk/lib/index.js:434:196750)
    at async /Users/yutaokos/src/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/node_modules/aws-cdk/lib/index.js:434:178719

 ❌ Deployment failed: Error: The stack named amazon-chime-sdk-call-analytics-real-time-summarizer failed to deploy: CREATE_FAILED (The following resource(s) failed to create: [ServerResourcesInstance6D1E6643aef0c00e63d6511d]. ): Received FAILURE signal with UniqueId i-01432672bfed0348a
    at FullCloudFormationDeployment.monitorDeployment (/Users/yutaokos/src/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/node_modules/aws-cdk/lib/index.js:431:10615)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.deployStack2 [as deployStack] (/Users/yutaokos/src/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/node_modules/aws-cdk/lib/index.js:434:196750)
    at async /Users/yutaokos/src/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/node_modules/aws-cdk/lib/index.js:434:178719

The stack named amazon-chime-sdk-call-analytics-real-time-summarizer failed to deploy: CREATE_FAILED (The following resource(s) failed to create: [ServerResourcesInstance6D1E6643aef0c00e63d6511d]. ): Received FAILURE signal with UniqueId i-01432672bfed0348a
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
👾 Task "launch" failed when executing "yarn && yarn projen && yarn build && yarn cdk bootstrap && yarn cdk deploy --no-rollback --require-approval never" (cwd: /Users/yutaokos/src/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

#### EC2 > Server Instance > Get system log
![スクリーンショット 2024-03-06 0 21 52](https://github.com/aws-samples/amazon-chime-sdk-call-analytics-real-time-summarizer/assets/37532269/652d1daa-e95c-4293-a1ae-bfeabc60c50b)

```

[   87.454875] cloud-init[1249]: + echo 'INSTANCE_ID: i-01432672bfed0348a'
[   87.455038] cloud-init[1249]: INSTANCE_ID: i-01432672bfed0348a
[   87.455231] cloud-init[1249]: + aws chime put-voice-connector-origination --voice-connector-id fcwftymex1lpaoyai9xhah --origination '{"Routes": [{"Host": "54.156.115.168","Port": 5060,"Protocol": "UDP","Priority": 1,"Weight": 1}],"Disabled": false}'
[   87.455368] cloud-init[1249]: An error occurred (ForbiddenException) when calling the PutVoiceConnectorOrigination operation: Account Id 706162977618 is not authorized to call deprecated Amazon Chime SDK API on the "chime" endpoint, use one of the "*-chime*" endpoints instead.
[   87.455539] cloud-init[1249]: 2024-03-05 14:22:09,083 [ERROR] Error encountered during build of config: Command 001 failed
[   87.455708] cloud-init[1249]: Traceback (most recent call last):
[   87.455865] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/construction.py", line 579, in run_config
[   87.456051] cloud-init[1249]:     CloudFormationCarpenter(config, self._auth_config, self.strict_mode).build(worklog)
[   87.456205] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/construction.py", line 277, in build
[   87.456366] cloud-init[1249]:     changes['commands'] = CommandTool().apply(
[   87.456534] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/command_tool.py", line 127, in apply
[   87.456704] cloud-init[1249]:     raise ToolError(u"Command %s failed" % name)
[   87.456860] cloud-init[1249]: cfnbootstrap.construction_errors.ToolError: Command 001 failed
[   87.457027] cloud-init[1249]: 2024-03-05 14:22:09,083 [ERROR] -----------------------BUILD FAILED!------------------------
[   87.457201] cloud-init[1249]: 2024-03-05 14:22:09,084 [ERROR] Unhandled exception during build: Command 001 failed
[   87.457367] cloud-init[1249]: Traceback (most recent call last):
[   87.457519] cloud-init[1249]:   File "/opt/aws/bin/cfn-init", line 181, in <module>
[   87.457687] cloud-init[1249]:     worklog.build(metadata, configSets, strict_mode)
[   87.457854] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/construction.py", line 137, in build
[   87.458195] cloud-init[1249]:     Contractor(metadata, strict_mode).build(configSets, self)
[   87.458347] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/construction.py", line 567, in build
[   87.498420] cloud-init[1249]:     self.run_config(config, worklog)
[   87.498726] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/construction.py", line 579, in run_config
[   87.498869] cloud-init[1249]:     CloudFormationCarpenter(config, self._auth_config, self.strict_mode).build(worklog)
[   87.499035] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/construction.py", line 277, in build
[   87.499219] cloud-init[1249]:     changes['commands'] = CommandTool().apply(
[   87.499361] cloud-init[1249]:   File "/usr/local/lib/python3.10/dist-packages/cfnbootstrap/command_tool.py", line 127, in apply
[   87.499544] cloud-init[1249]:     raise ToolError(u"Command %s failed" % name)
[   87.499723] cloud-init[1249]: cfnbootstrap.construction_errors.ToolError: Command 001 failed
[   87.499866] cloud-init[1249]: 2024-03-05 14:22:09,355 [DEBUG] CloudFormation client initialized with endpoint https://cloudformation.us-east-1.amazonaws.com
[   87.500045] cloud-init[1249]: 2024-03-05 14:22:09,356 [DEBUG] Signaling resource ServerResourcesInstance6D1E6643aef0c00e63d6511d in stack amazon-chime-sdk-call-analytics-real-time-summarizer with unique ID i-01432672bfed0348a and status FAILURE
ci-info: no authorized SSH keys fingerprints found for user ubuntu.
<14>Mar  5 14:22:09 cloud-init: #############################################################
<14>Mar  5 14:22:09 cloud-init: -----BEGIN SSH HOST KEY FINGERPRINTS-----
```